### PR TITLE
Write bake file for building slurm services

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @abatilo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: "Build"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.event_name == 'push' && 'main' || github.event.number }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - if: github.event_name == 'push'
+        uses: docker/bake-action@v5
+        env:
+          SOURCE_DATE_EPOCH: 0
+        with:
+          push: true
+
+      - if: github.event_name == 'pull_request'
+        uses: docker/bake-action@v5
+        env:
+          SOURCE_DATE_EPOCH: 0
+        with:
+          push: false
+          set: |
+            *.cache-to=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# Use an ubuntu base image
+# This stage is for building the various slurm binaries as debian packages
+# We download slurm and install all of its buildtime dependencies
+FROM ubuntu:22.04 AS slurm-base
+ENV DEBIAN_FRONTEND=noninteractive
+ARG SLURM_VERSION
+WORKDIR /opt
+
+# hadolint ignore=DL3003,DL3009,DL4006
+RUN <<EOF
+rm -f /etc/apt/apt.conf.d/docker-clean
+echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+apt-get update
+apt-get install --no-install-recommends -y build-essential=12.9ubuntu3 fakeroot=1.28-1ubuntu1 devscripts=2.22.1ubuntu1 curl=7.81.0-1ubuntu1.16 equivs=2.3.1 ca-certificates=20230311ubuntu0.22.04.1
+curl -LO https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2
+tar -xaf slurm-${SLURM_VERSION}.tar.bz2
+cd slurm-${SLURM_VERSION} || exit 1
+echo "y" | mk-build-deps -i debian/control
+EOF
+
+# In slurm-builder we build the debian packages
+FROM slurm-base AS slurm-builder
+ARG SLURM_VERSION
+WORKDIR /opt/slurm-${SLURM_VERSION}
+RUN debuild -b -uc -us
+
+# In slurm-runtime, we use the base which has the buildtime dependencies and
+# then add runtime dependencies like munge.
+# We remove things like the slurm source code since we don't need it at runtime.
+# All slurm subsystems also require the slurm-smd package so we install that
+# here.
+FROM slurm-base AS slurm-runtime
+ARG SLURM_VERSION
+WORKDIR /opt/slurm-${SLURM_VERSION}
+
+RUN <<EOF
+apt-get install --no-install-recommends -y munge=* libmunge-dev=*
+rm -rf /var/lib/apt/lists/*
+rm -rf /opt/slurm-${SLURM_VERSION}
+EOF
+
+COPY --from=slurm-builder \
+  /opt/slurm-smd_${SLURM_VERSION}-1_amd64.deb \
+  /opt/
+RUN <<EOF
+dpkg -i "/opt/slurm-smd_${SLURM_VERSION}-1_amd64.deb"
+rm "/opt/slurm-smd_${SLURM_VERSION}-1_amd64.deb"
+EOF
+
+FROM slurm-runtime AS slurmdbd
+COPY --from=slurm-builder \
+  /opt/slurm-smd-slurmdbd_${SLURM_VERSION}-1_amd64.deb \
+  /opt/
+RUN <<EOF
+dpkg -i "/opt/slurm-smd-slurmdbd_${SLURM_VERSION}-1_amd64.deb"
+rm "/opt/slurm-smd-slurmdbd_${SLURM_VERSION}-1_amd64.deb"
+EOF
+
+FROM slurm-runtime AS slurmctld
+COPY --from=slurm-builder \
+  /opt/slurm-smd-slurmctld_${SLURM_VERSION}-1_amd64.deb \
+  /opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb \
+  /opt/
+
+RUN <<EOF
+dpkg -i "/opt/slurm-smd-slurmctld_${SLURM_VERSION}-1_amd64.deb"
+dpkg -i "/opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb"
+rm "/opt/slurm-smd-slurmctld_${SLURM_VERSION}-1_amd64.deb" "/opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb"
+EOF
+
+FROM slurm-runtime AS slurmd
+COPY --from=slurm-builder \
+  /opt/slurm-smd-slurmd_${SLURM_VERSION}-1_amd64.deb \
+  /opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb \
+  /opt/
+RUN <<EOF
+dpkg -i "/opt/slurm-smd-slurmd_${SLURM_VERSION}-1_amd64.deb"
+dpkg -i "/opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb"
+rm "/opt/slurm-smd-slurmd_${SLURM_VERSION}-1_amd64.deb" "/opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb"
+EOF
+
+FROM slurm-runtime AS login
+COPY --from=slurm-builder \
+  /opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb \
+  /opt/
+RUN <<EOF
+dpkg -i "/opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb"
+rm "/opt/slurm-smd-client_${SLURM_VERSION}-1_amd64.deb"
+EOF

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # sok
-Learning how to run slurm on kubernetes
+
+Learning how to run Slurm on Kubernetes.
+
+The intention of this repo is to experiment with building, and deploying Slurm
+on Kubernetes. This is strictly an educational repository for me to learn in.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,34 @@
+variable "GITHUB_SHA" { default = "latest" }
+variable "SLURM_VERSION" { default = "24.05.1" }
+
+group "default" {
+  targets = [
+    "slurm",
+  ]
+}
+
+target "slurm" {
+  matrix = {
+    app = [
+      { name = "slurmdbd",  },
+      { name = "slurmctld", },
+      { name = "slurmd",    },
+      { name = "login",     },
+    ]
+  }
+
+  name = "${app.name}"
+  args = {
+    SLURM_VERSION = "${SLURM_VERSION}"
+  }
+  target = "${app.name}"
+  output = [
+    "type=image,name=ghcr.io/abatilo/sok/${app.name}:${GITHUB_SHA},rewrite-timestamp=true,oci-mediatypes=true,compression=zstd,compression-level=22,force-compression=true",
+  ]
+  tags = [
+    "ghcr.io/abatilo/sok/${app.name}:${GITHUB_SHA}"
+  ]
+
+  cache-from = ["type=gha,scope=${app.name}"]
+  cache-to = ["type=gha,mode=max,scope=${app.name}"]
+}


### PR DESCRIPTION
Each slurm service requires a slightly different set of packages. Here's
a docker bake file that re-uses some layers and then parallelizes
building each of the other services.
